### PR TITLE
Added docker file to enable easy running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+From node:14-alpine
+
+WORKDIR /app
+
+COPY . /app
+
+EXPOSE 8080
+
+RUN npm install
+CMD ["npm", "run", "dev"]

--- a/development-compose.yml
+++ b/development-compose.yml
@@ -1,0 +1,7 @@
+services:
+  threejs:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    ports:
+      - 8080:8080

--- a/readme.md
+++ b/readme.md
@@ -15,3 +15,14 @@ npm run dev
 # Build for production in the dist/ directory
 npm run build
 ```
+## Setup with Docker
+Download [Docker](https://www.docker.com/products/docker-desktop/)
+
+RUN the following command:
+``` bash
+# Build the container with compatible webpack node version
+
+docker compose -f development-compose.yml up
+```
+
+After compilation, the Red ring must be visible.


### PR DESCRIPTION
Faced an issue with Current Node version(20.11.1). This starter folder was failing and had to literally shift my attention from Three.js video to getting the Red ring. Added a docker file so that others can run this in future.